### PR TITLE
Correct arguments for `woocommerce_checkout_order_processed`

### DIFF
--- a/woocommerce-order-simulator.php
+++ b/woocommerce-order-simulator.php
@@ -242,9 +242,9 @@ PRIMARY KEY  (number)
                     update_post_meta( $order_id, '_'.$key, $value );
                 }
 
-                do_action( 'woocommerce_checkout_order_processed', $order_id, $data );
-
                 $order = new WC_Order($order_id);
+             
+                do_action( 'woocommerce_checkout_order_processed', $order_id, $data, $order );
 
                 // figure out the order status
                 $status = 'completed';


### PR DESCRIPTION
The `woocommerce_checkout_order_processed` hook requires three arguments (`$order_id`, `$data` and `$order`), but only two were being passed. This adds the `$order` argument to it, which prevents fatal errors on other extensions that make use of the hook.